### PR TITLE
feat: Support for transient settings

### DIFF
--- a/src/config/settings_loader.py
+++ b/src/config/settings_loader.py
@@ -1,6 +1,7 @@
 import os
 import json
 from pathlib import Path
+from django.core.exceptions import ObjectDoesNotExist
 from .models import Settings, SettingType
 
 def cast_env_value(env_value, setting_type):
@@ -17,23 +18,46 @@ def load_and_sync_settings():
     with open(config_path) as f:
         default_settings = json.load(f)
 
+    is_transient = os.environ.get("TRANSIENT_SETTINGS", "").lower() == "true"
+
     for setting in default_settings:
         key = setting['name']
         default_value = setting['value']
         setting_type = setting.get('type', 'string')
 
-        # Check for env override
+        # Get override from environment if present
         env_value = os.environ.get(key)
         value = cast_env_value(env_value, setting_type) if env_value is not None else default_value
 
-        # Upsert all fields
-        Settings.objects.update_or_create(
-            name=key,
-            defaults={
-                'display_name': setting.get('display_name', key),
-                'value': value,
-                'description': setting.get('description', ''),
-                'group': setting.get('group', 'General'),
-                'type': setting_type,
-            }
+        # Prepare common field values
+        fields = {
+            'display_name': setting.get('display_name', key),
+            'value': value,
+            'description': setting.get('description', ''),
+            'group': setting.get('group', 'General'),
+            'type': setting_type,
+        }
+
+        try:
+            existing_obj = Settings.objects.get(name=key)
+        except ObjectDoesNotExist:
+            Settings.objects.create(name=key, **fields)
+            continue
+
+        if is_transient:
+            for field, val in fields.items():
+                setattr(existing_obj, field, val)
+            existing_obj.save()
+            continue
+
+        # Compare only non-value fields to determine if update is needed
+        needs_update = any(
+            getattr(existing_obj, field) != val
+            for field, val in fields.items()
+            if field != 'value'  # 'value' is only updated when other fields differ
         )
+
+        if needs_update:
+            for field, val in fields.items():
+                setattr(existing_obj, field, val)
+            existing_obj.save()


### PR DESCRIPTION
his update improves how settings are loaded and synchronized from the settings.json template during app initialization or setup.

## Changes Made
- Added support for `TRANSIENT_SETTINGS` environment variable:
  - When enabled (`TRANSIENT_SETTINGS=true`), all settings (including value) will be forcibly updated from `settings.json`, even if the setting already exists in the database.

- Default behavior (when `TRANSIENT_SETTINGS` is not set):

  - Settings are only updated if any of the metadata fields (display_name, description, group, type) in the JSON template differ from what’s stored in the database.

  - In such cases, the value is also updated to stay in sync with the updated metadata.

Fixes #1 